### PR TITLE
fix duplicated custom menus

### DIFF
--- a/VVDiscoDisplay/VVDiscoDisplay.cs
+++ b/VVDiscoDisplay/VVDiscoDisplay.cs
@@ -6,7 +6,7 @@ using VesselViewRPM.menus;
 
 namespace VVDiscoDisplay
 {
-    [KSPAddon(KSPAddon.Startup.Flight, false)]
+    [KSPAddon(KSPAddon.Startup.Flight, true)]
     public class VVDiscoDisplay : MonoBehaviour
     {
 

--- a/VVPartSelector/VVPartSelector.cs
+++ b/VVPartSelector/VVPartSelector.cs
@@ -6,7 +6,7 @@ using VesselView;
 
 namespace VVPartSelector
 {
-    [KSPAddon(KSPAddon.Startup.Flight, false)]
+    [KSPAddon(KSPAddon.Startup.Flight, true)]
     public class VVPartSelector : MonoBehaviour
     {
 


### PR DESCRIPTION
These classes registered their menu handlers on each entry into the flight scene, so you'd get multiple copies of the menu in the MFD.