### PR TITLE
Only require `ToolbarController` and  `ClickThroughBlocker` when using VesselViewPlugin

### DIFF
--- a/VVDiscoDisplay/Properties/AssemblyInfo.cs
+++ b/VVDiscoDisplay/Properties/AssemblyInfo.cs
@@ -34,6 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("1.0.0.43")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
-[assembly: KSPAssemblyDependency("ToolbarController", 1, 0)]

--- a/VVDiscoDisplay/obj/Debug/VVDiscoDisplay.csproj.FileListAbsolute.txt
+++ b/VVDiscoDisplay/obj/Debug/VVDiscoDisplay.csproj.FileListAbsolute.txt
@@ -17,13 +17,10 @@ D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VVDiscoDisplay.pdb
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VesselView.dll
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VesselViewPlugin.dll
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VesselViewRPM.dll
-D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\ToolbarControl.dll
-D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\ClickThroughBlocker.dll
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\JSIPartUtilities.dll
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VesselViewPlugin.pdb
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VesselViewRPM.pdb
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\VesselView.pdb
-D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\bin\Debug\ClickThroughBlocker.pdb
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\obj\Debug\VVDiscoDisplay.csproj.CopyComplete
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\obj\Debug\VVDiscoDisplay.dll
 D:\Users\jbb\github\VesselViewer\VVDiscoDisplay\obj\Debug\VVDiscoDisplay.pdb

--- a/VVPartSelector/Properties/AssemblyInfo.cs
+++ b/VVPartSelector/Properties/AssemblyInfo.cs
@@ -34,6 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("1.0.0.40")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
-[assembly: KSPAssemblyDependency("ToolbarController", 1, 0)]

--- a/VesselView/Properties/AssemblyInfo.cs
+++ b/VesselView/Properties/AssemblyInfo.cs
@@ -34,6 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("1.0.0.8")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
-[assembly: KSPAssemblyDependency("ToolbarController", 1, 0)]

--- a/VesselViewRPM/Properties/AssemblyInfo.cs
+++ b/VesselViewRPM/Properties/AssemblyInfo.cs
@@ -34,6 +34,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("1.0.0.11")]
 //[assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 0)]
-[assembly: KSPAssemblyDependency("ToolbarController", 1, 0)]


### PR DESCRIPTION
Makes the `ToolbarController` and `ClickThroughBlocker` dependencies required only for VesselViewPlugin, as they are unused otherwise.